### PR TITLE
Switched to using a mirrors array for use by debootstrap

### DIFF
--- a/template_debian/02_install_groups_wheezy.sh
+++ b/template_debian/02_install_groups_wheezy.sh
@@ -16,7 +16,8 @@ updateDebianSourceList
 #### '----------------------------------------------------------------------
 info ' Adding wheezy backports repository.'
 #### '----------------------------------------------------------------------
-source="deb ${DEBIAN_MIRROR} wheezy-backports main"
+mirror="$(cat ${INSTALLDIR}/${TMPDIR}/.mirror)"
+source="deb ${mirror} wheezy-backports main"
 if ! grep -r -q "$source" "${INSTALLDIR}/etc/apt/sources.list"*; then
     touch "${INSTALLDIR}/etc/apt/sources.list"
     echo "$source" >> "${INSTALLDIR}/etc/apt/sources.list"

--- a/template_debian/vars.sh
+++ b/template_debian/vars.sh
@@ -9,9 +9,8 @@ source ./functions.sh
 
 # ------------------------------------------------------------------------------
 # Temp directory to place installation files and progress markers
-# (Do not use /tmp since if built in a real VM, /tmp will be empty on a reboot)
 # ------------------------------------------------------------------------------
-TMPDIR="/var/lib/qubes-whonix/install"
+TMPDIR="/tmp"
 
 # ------------------------------------------------------------------------------
 # The codename of the debian version to install.
@@ -22,13 +21,11 @@ DEBIANVERSION=${DIST}
 # ------------------------------------------------------------------------------
 # Location to grab Debian packages
 # ------------------------------------------------------------------------------
-DEBIAN_MIRROR=http://ftp.us.debian.org/debian
-
-# TODO: Not yet implemented
-DEBIAN_MIRRORS=('http://ftp.us.debian.org/debian',
-                'http://http.debian.net/debian,
-                'http://ftp.ca.debian.org/debian,
-               )
+DEBIAN_MIRRORS=(
+    'http://http.debian.net/debian'
+    'http://ftp.us.debian.org/debian'
+    'http://ftp.ca.debian.org/debian'
+)
 
 # ------------------------------------------------------------------------------
 # apt-get configuration options

--- a/template_qubuntu/vars.sh
+++ b/template_qubuntu/vars.sh
@@ -9,23 +9,21 @@ source ./functions.sh
 
 # ------------------------------------------------------------------------------
 # Temp directory to place installation files and progress markers
-# (Do not use /tmp since if built in a real VM, /tmp will be empty on a reboot)
 # ------------------------------------------------------------------------------
-TMPDIR="/var/lib/qubes-whonix/install"
-
-# Location to grab ubuntu packages
-DEBIAN_MIRROR=http://archive.ubuntu.com/ubuntu
+TMPDIR="/tmp"
 
 # ------------------------------------------------------------------------------
 # Location to grab Ubuntu packages
 # ------------------------------------------------------------------------------
-DEBIAN_MIRROR=http://archive.ubuntu.com/ubuntu
-
-# TODO: Not yet implemented
-DEBIAN_MIRRORS=('http://archive.ubuntu.com/ubuntu',
-		       )
+DEBIAN_MIRRORS=(
+    'http://archive.ubuntu.com/ubuntu'
+)
 
 # ------------------------------------------------------------------------------
 # apt-get configuration options
 # ------------------------------------------------------------------------------
 APT_GET_OPTIONS="-o Dpkg::Options::="--force-confnew" --force-yes --yes"
+
+containsFlavor 'no-recommends' && {
+    APT_GET_OPTIONS+=" -o APT::Install-Recommends=0  -o APT::Install-Suggests=0" 
+} || true


### PR DESCRIPTION
- Often the signle mirror would fail for sometimes hours at a time so the
  mirrors list was added
- Mirrors will be cycled through until exhausted at which point it would fail
- The mirrors array is in vars.sh