### PR TITLE
Speedup

### DIFF
--- a/Makefile.debian
+++ b/Makefile.debian
@@ -92,6 +92,10 @@ Description: Apt repository with qubes domU support tools for $(DISTRIBUTION_CAP
 endef
 export aptdistributions
 
+ifdef REPO_PROXY
+  APT_GET_OPTIONS += -o Acquire::http::Proxy=$(REPO_PROXY)
+endif
+
 dist-prepare-chroot: $(CHROOT_DIR)/home/user/.prepared_base
 	@if [ $(VERBOSE) -gt 0 ]; then \
 		echo "-> dist-prepare-chroot for $(DIST)"; \

--- a/Makefile.debian
+++ b/Makefile.debian
@@ -129,19 +129,19 @@ dist-build-dep:
 	    mkdir -p "$(BUILDER_REPO_DIR)/dists";\
 	fi
 	$(DEBIAN_PLUGIN_DIR)/update-local-repo.sh $(DIST)
-	sudo chroot $(CHROOT_DIR) apt-get update
+	sudo chroot $(CHROOT_DIR) apt-get ${APT_GET_OPTIONS} update
 
 	# Parse debian/control for Build-Depends and install
 	$(DEBIAN_PARSER) control --build-depends $(DEBIAN_CHROOT_DIR)/control |\
-		xargs sudo chroot $(CHROOT_DIR) apt-get install -y
+		xargs sudo chroot $(CHROOT_DIR) apt-get $(APT_GET_OPTIONS) install -y
 
 	# Parse debian/control for custom X-Qubes-Build-Depends-[debian] depends and install
 	$(DEBIAN_PARSER) control --qubes-build-depends $(DISTRIBUTION) $(DEBIAN_CHROOT_DIR)/control |\
-		xargs sudo chroot $(CHROOT_DIR) apt-get install -y
+		xargs sudo chroot $(CHROOT_DIR) apt-get $(APT_GET_OPTIONS) install -y
 
 	# Parse debian/control for custom X-Qubes-Build-Depends-[wheezy/jessie] depends and install
 	$(DEBIAN_PARSER) control --qubes-build-depends $(DIST) $(DEBIAN_CHROOT_DIR)/control |\
-		xargs sudo chroot $(CHROOT_DIR) apt-get install -y
+		xargs sudo chroot $(CHROOT_DIR) apt-get $(APT_GET_OPTIONS) install -y
 
 dist-package:
 ifndef PACKAGE

--- a/prepare-chroot-debian
+++ b/prepare-chroot-debian
@@ -23,6 +23,10 @@ fi
 # Build packages to be installed to allow building of Qubes modules
 # ------------------------------------------------------------------------------
 BUILDPACKAGES="reprepro build-essential devscripts git git-buildpackage pbuilder debhelper quilt libxen-dev python libpulse-dev libtool automake xorg-dev xutils-dev libxdamage-dev libxcomposite-dev libxt-dev libx11-dev"
+if [ "0${BUILDER_TURBO_MODE}" -gt 0 ]; then
+    APT_GET_OPTIONS+=" -o Dpkg::Options::=--force-unsafe-io"
+    eatmydata_maybe=eatmydata
+fi
 
 if ! [ -d $DIR/home/user ]; then
     # --------------------------------------------------------------------------
@@ -31,7 +35,7 @@ if ! [ -d $DIR/home/user ]; then
     mkdir -p $DIR
     echo "-> Installing debian build chroot..."
     COMPONENTS="" debootstrap --arch=amd64 \
-                --include=ncurses-term,debian-keyring \
+                --include=ncurses-term,debian-keyring,$eatmydata_maybe \
                 --keyring=${DEBIAN_PLUGIN_DIR}keys/$DIST-debian-archive-keyring.gpg \
                 $DEBIANVERSION $DIR http://http.debian.net/debian \
                 || { echo "Error in debootstrap"; exit 1; }
@@ -76,7 +80,10 @@ else
 
     # update chroot
     chroot $DIR apt-get update
-    chroot $DIR apt-get -y upgrade
+    if [ -n "$eatmydata_maybe" -a ! -f "$DIR/usr/lib/libeatmydata/libeatmydata.so" ]; then
+        chroot $DIR apt-get $APT_GET_OPTIONS -y install eatmydata
+    fi
+    chroot $DIR $eatmydata_maybe apt-get $APT_GET_OPTIONS -y upgrade
 fi
 
 # ------------------------------------------------------------------------------
@@ -89,7 +96,7 @@ fi
 # ------------------------------------------------------------------------------
 # Install all build packages specified
 # ------------------------------------------------------------------------------
-chroot $DIR apt-get -y install $BUILDPACKAGES
+chroot $DIR $eatmydata_maybe apt-get $APT_GET_OPTIONS -y install $BUILDPACKAGES
 
 if [ "$DIST" == "wheezy" ]; then
     # Looks like a SID only package is being used to build packages
@@ -100,7 +107,7 @@ if [ "$DIST" == "wheezy" ]; then
         echo "$source" >> "${DIR}/etc/apt/sources.list"
     fi
     chroot $DIR apt-get update
-    chroot $DIR apt-get -t wheezy-backports install -y dh-systemd config-package-dev
+    chroot $DIR $eatmydata_maybe apt-get $APT_GET_OPTIONS -t wheezy-backports install -y dh-systemd config-package-dev
 fi
 
 # ------------------------------------------------------------------------------

--- a/prepare-chroot-debian
+++ b/prepare-chroot-debian
@@ -79,7 +79,7 @@ else
     rm -f $DIR/etc/apt/sources.list.d/qubes-builder.list
 
     # update chroot
-    chroot $DIR apt-get update
+    chroot $DIR apt-get $APT_GET_OPTIONS update
     if [ -n "$eatmydata_maybe" -a ! -f "$DIR/usr/lib/libeatmydata/libeatmydata.so" ]; then
         chroot $DIR apt-get $APT_GET_OPTIONS -y install eatmydata
     fi
@@ -106,7 +106,7 @@ if [ "$DIST" == "wheezy" ]; then
         touch "${DIR}/etc/apt/sources.list"
         echo "$source" >> "${DIR}/etc/apt/sources.list"
     fi
-    chroot $DIR apt-get update
+    chroot $DIR apt-get $APT_GET_OPTIONS update
     chroot $DIR $eatmydata_maybe apt-get $APT_GET_OPTIONS -t wheezy-backports install -y dh-systemd config-package-dev
 fi
 
@@ -145,7 +145,7 @@ cp $CACHEDIR/repo-pubring.gpg $DIR/etc/apt/trusted.gpg.d/qubes-builder.gpg
 # ------------------------------------------------------------------------------
 # Refresh package list (but not quebes repo since it does not yet exist)
 # ------------------------------------------------------------------------------
-chroot $DIR apt-get update
+chroot $DIR apt-get $APT_GET_OPTIONS update
 
 # ------------------------------------------------------------------------------
 # Update debian apt sources list to use local qubes repo

--- a/prepare-chroot-debian
+++ b/prepare-chroot-debian
@@ -28,13 +28,18 @@ if [ "0${BUILDER_TURBO_MODE}" -gt 0 ]; then
     eatmydata_maybe=eatmydata
 fi
 
+if [ -n "${REPO_PROXY}" ]; then
+    APT_GET_OPTIONS+=" -o Acquire::http::Proxy=${REPO_PROXY}"
+    DEBOOTSTRAP_PREFIX+=" env http_proxy=${REPO_PROXY}"
+fi
+
 if ! [ -d $DIR/home/user ]; then
     # --------------------------------------------------------------------------
     # Install debian choot if /home/user does not exist (initial run)
     # --------------------------------------------------------------------------
     mkdir -p $DIR
     echo "-> Installing debian build chroot..."
-    COMPONENTS="" debootstrap --arch=amd64 \
+    COMPONENTS="" $DEBOOTSTRAP_PREFIX debootstrap --arch=amd64 \
                 --include=ncurses-term,debian-keyring,$eatmydata_maybe \
                 --keyring=${DEBIAN_PLUGIN_DIR}keys/$DIST-debian-archive-keyring.gpg \
                 $DEBIANVERSION $DIR http://http.debian.net/debian \

--- a/prepare-chroot-qubuntu
+++ b/prepare-chroot-qubuntu
@@ -18,6 +18,10 @@ fi
 # Build packages to be installed to allow building of Qubes modules
 # ------------------------------------------------------------------------------
 BUILDPACKAGES="reprepro build-essential devscripts git git-buildpackage pbuilder debhelper quilt libxen-dev python libpulse-dev libtool automake xorg-dev xutils-dev libxdamage-dev libxcomposite-dev libxt-dev libx11-dev"
+if [ "0${BUILDER_TURBO_MODE}" -gt 0 ]; then
+    APT_GET_OPTIONS+=" -o Dpkg::Options::=--force-unsafe-io"
+    eatmydata_maybe=eatmydata
+fi
 
 INITIAL=
 
@@ -29,7 +33,7 @@ if ! [ -d $DIR/home/user ]; then
     mkdir -p $DIR
     echo "-> Installing qubuntu build chroot..."
     COMPONENTS="" debootstrap --arch=amd64 \
-                --include=ncurses-term,ubuntu-keyring \
+                --include=ncurses-term,ubuntu-keyring,$eatmydata_maybe \
                 --keyring=${DEBIAN_PLUGIN_DIR}/keys/$DIST-qubuntu-archive-keyring.gpg \
                 $DEBIANVERSION $DIR http://archive.ubuntu.com/ubuntu \
                 || { echo "Error in debootstrap"; exit 1; }
@@ -74,7 +78,7 @@ else
 
     # update chroot
     chroot $DIR apt-get update
-    chroot $DIR apt-get -y upgrade
+    chroot $DIR $eatmydata_maybe apt-get $APT_GET_OPTIONS -y upgrade
 fi
 
 # ------------------------------------------------------------------------------
@@ -93,13 +97,13 @@ chroot $DIR apt-get update
 # ------------------------------------------------------------------------------
 # Install all build packages specified
 # ------------------------------------------------------------------------------
-chroot $DIR apt-get -y install $BUILDPACKAGES
+chroot $DIR $eatmydata_maybe apt-get $APT_GET_OPTIONS -y install $BUILDPACKAGES
 
 # Install pulseaudio5
-chroot $DIR apt-get install -y software-properties-common
+chroot $DIR apt-get $APT_GET_OPTIONS install -y software-properties-common
 chroot $DIR add-apt-repository -y ppa:ubuntu-audio-dev/pulse-testing
 chroot $DIR apt-get update
-chroot $DIR apt-get install -y libpulse-dev
+chroot $DIR apt-get $APT_GET_OPTIONS install -y libpulse-dev
 
 # ------------------------------------------------------------------------------
 # Install keyring

--- a/prepare-chroot-qubuntu
+++ b/prepare-chroot-qubuntu
@@ -77,7 +77,7 @@ else
     rm -f $DIR/etc/apt/sources.list.d/qubes-builder.list
 
     # update chroot
-    chroot $DIR apt-get update
+    chroot $DIR apt-get $APT_GET_OPTIONS update
     chroot $DIR $eatmydata_maybe apt-get $APT_GET_OPTIONS -y upgrade
 fi
 
@@ -92,7 +92,7 @@ fi
 # Add universe to sources.list
 # ------------------------------------------------------------------------------
 sed -i "s/${DIST} main$/${DIST} main universe/g" $DIR/etc/apt/sources.list
-chroot $DIR apt-get update
+chroot $DIR apt-get $APT_GET_OPTIONS update
 
 # ------------------------------------------------------------------------------
 # Install all build packages specified
@@ -102,7 +102,7 @@ chroot $DIR $eatmydata_maybe apt-get $APT_GET_OPTIONS -y install $BUILDPACKAGES
 # Install pulseaudio5
 chroot $DIR apt-get $APT_GET_OPTIONS install -y software-properties-common
 chroot $DIR add-apt-repository -y ppa:ubuntu-audio-dev/pulse-testing
-chroot $DIR apt-get update
+chroot $DIR apt-get $APT_GET_OPTIONS update
 chroot $DIR apt-get $APT_GET_OPTIONS install -y libpulse-dev
 
 # ------------------------------------------------------------------------------

--- a/prepare-chroot-qubuntu
+++ b/prepare-chroot-qubuntu
@@ -23,6 +23,11 @@ if [ "0${BUILDER_TURBO_MODE}" -gt 0 ]; then
     eatmydata_maybe=eatmydata
 fi
 
+if [ -n "${REPO_PROXY}" ]; then
+    APT_GET_OPTIONS+=" -o Acquire::http::Proxy=${REPO_PROXY}"
+    DEBOOTSTRAP_PREFIX+=" env http_proxy=${REPO_PROXY}"
+fi
+
 INITIAL=
 
 if ! [ -d $DIR/home/user ]; then
@@ -32,7 +37,7 @@ if ! [ -d $DIR/home/user ]; then
     INITIAL=1
     mkdir -p $DIR
     echo "-> Installing qubuntu build chroot..."
-    COMPONENTS="" debootstrap --arch=amd64 \
+    COMPONENTS="" $DEBOOTSTRAP_PREFIX debootstrap --arch=amd64 \
                 --include=ncurses-term,ubuntu-keyring,$eatmydata_maybe \
                 --keyring=${DEBIAN_PLUGIN_DIR}/keys/$DIST-qubuntu-archive-keyring.gpg \
                 $DEBIANVERSION $DIR http://archive.ubuntu.com/ubuntu \

--- a/template_debian/01_install_core.sh
+++ b/template_debian/01_install_core.sh
@@ -23,7 +23,7 @@ bootstrap() {
         echo ${mirror} > "${INSTALLDIR}/${TMPDIR}/.mirror"
         COMPONENTS="" debootstrap \
             --arch=amd64 \
-            --include="ncurses-term locales tasksel" \
+            --include="ncurses-term,locales,tasksel,$eatmydata_maybe" \
             --components=main \
             --keyring="${SCRIPTSDIR}/../keys/${DIST}-${DISTRIBUTION}-archive-keyring.gpg" \
             "${DIST}" "${INSTALLDIR}" "${mirror}" && return 0

--- a/template_debian/01_install_core.sh
+++ b/template_debian/01_install_core.sh
@@ -21,7 +21,7 @@ bootstrap() {
             mkdir -p "${INSTALLDIR}/${TMPDIR}"
         fi
         echo ${mirror} > "${INSTALLDIR}/${TMPDIR}/.mirror"
-        COMPONENTS="" debootstrap \
+        COMPONENTS="" $DEBOOTSTRAP_PREFIX debootstrap \
             --arch=amd64 \
             --include="ncurses-term,locales,tasksel,$eatmydata_maybe" \
             --components=main \

--- a/template_debian/distribution.sh
+++ b/template_debian/distribution.sh
@@ -145,7 +145,7 @@ function prepareChroot() {
 function aptUpgrade() {
     aptUpdate
     DEBIAN_FRONTEND="noninteractive" DEBIAN_PRIORITY="critical" DEBCONF_NOWARNINGS="yes" \
-        chroot env APT_LISTCHANGES_FRONTEND=none apt-get upgrade -u -y
+        chroot env APT_LISTCHANGES_FRONTEND=none $eatmydata_maybe apt-get upgrade -u -y
 }
 
 # ==============================================================================
@@ -154,7 +154,7 @@ function aptUpgrade() {
 function aptDistUpgrade() {
     aptUpdate
     DEBIAN_FRONTEND="noninteractive" DEBIAN_PRIORITY="critical" DEBCONF_NOWARNINGS="yes" \
-        chroot env APT_LISTCHANGES_FRONTEND=none apt-get dist-upgrade -u -y
+        chroot env APT_LISTCHANGES_FRONTEND=none $eatmydata_maybe apt-get dist-upgrade -u -y
 }
 
 # ==============================================================================
@@ -172,7 +172,7 @@ function aptUpdate() {
 function aptRemove() {
     files="$@"
     DEBIAN_FRONTEND="noninteractive" DEBIAN_PRIORITY="critical" DEBCONF_NOWARNINGS="yes" \
-        chroot apt-get ${APT_GET_OPTIONS} --force-yes remove ${files[@]}
+        chroot $eatmydata_maybe apt-get ${APT_GET_OPTIONS} --force-yes remove ${files[@]}
 }
 
 # ==============================================================================
@@ -181,7 +181,7 @@ function aptRemove() {
 function aptInstall() {
     files="$@"
     DEBIAN_FRONTEND="noninteractive" DEBIAN_PRIORITY="critical" DEBCONF_NOWARNINGS="yes" \
-        chroot apt-get ${APT_GET_OPTIONS} install ${files[@]}
+        chroot $eatmydata_maybe apt-get ${APT_GET_OPTIONS} install ${files[@]}
     retcode=$?
     chroot apt-get clean
     return $retcode

--- a/template_debian/distribution.sh
+++ b/template_debian/distribution.sh
@@ -145,7 +145,8 @@ function prepareChroot() {
 function aptUpgrade() {
     aptUpdate
     DEBIAN_FRONTEND="noninteractive" DEBIAN_PRIORITY="critical" DEBCONF_NOWARNINGS="yes" \
-        chroot env APT_LISTCHANGES_FRONTEND=none $eatmydata_maybe apt-get upgrade -u -y
+        chroot env APT_LISTCHANGES_FRONTEND=none $eatmydata_maybe \
+            apt-get ${APT_GET_OPTIONS} upgrade -u -y
 }
 
 # ==============================================================================
@@ -154,7 +155,8 @@ function aptUpgrade() {
 function aptDistUpgrade() {
     aptUpdate
     DEBIAN_FRONTEND="noninteractive" DEBIAN_PRIORITY="critical" DEBCONF_NOWARNINGS="yes" \
-        chroot env APT_LISTCHANGES_FRONTEND=none $eatmydata_maybe apt-get dist-upgrade -u -y
+        chroot env APT_LISTCHANGES_FRONTEND=none $eatmydata_maybe \
+            apt-get ${APT_GET_OPTIONS} dist-upgrade -u -y
 }
 
 # ==============================================================================
@@ -163,7 +165,7 @@ function aptDistUpgrade() {
 function aptUpdate() {
     debug "Updating system"
     DEBIAN_FRONTEND="noninteractive" DEBIAN_PRIORITY="critical" DEBCONF_NOWARNINGS="yes" \
-        chroot apt-get update
+        chroot apt-get ${APT_GET_OPTIONS} update
 }
 
 # ==============================================================================
@@ -183,7 +185,7 @@ function aptInstall() {
     DEBIAN_FRONTEND="noninteractive" DEBIAN_PRIORITY="critical" DEBCONF_NOWARNINGS="yes" \
         chroot $eatmydata_maybe apt-get ${APT_GET_OPTIONS} install ${files[@]}
     retcode=$?
-    chroot apt-get clean
+    chroot apt-get ${APT_GET_OPTIONS} clean
     return $retcode
 }
 
@@ -230,7 +232,7 @@ function installPackages() {
 # ==============================================================================
 function installSystemd() {
     buildStep "$0" "pre-systemd"
-    chroot apt-get update
+    chroot apt-get ${APT_GET_OPTIONS} update
 
     aptInstall systemd
     createDbusUuid
@@ -289,7 +291,7 @@ function updateQubuntuSourceList() {
         touch "${INSTALLDIR}/etc/apt/sources.list"
         echo "$source" >> "${INSTALLDIR}/etc/apt/sources.list"
     fi
-    chroot apt-get update
+    chroot apt-get ${APT_GET_OPTIONS} update
 }
 
 # ==============================================================================

--- a/template_debian/vars.sh
+++ b/template_debian/vars.sh
@@ -35,7 +35,12 @@ fi
 # ------------------------------------------------------------------------------
 # apt-get configuration options
 # ------------------------------------------------------------------------------
-APT_GET_OPTIONS="-o Dpkg::Options::="--force-confnew" --yes"
+APT_GET_OPTIONS="-o Dpkg::Options::=--force-confnew --yes"
+
+if [ "0${BUILDER_TURBO_MODE}" -gt 0 ]; then
+    APT_GET_OPTIONS+=" -o Dpkg::Options::=--force-unsafe-io"
+    eatmydata_maybe=eatmydata
+fi
 
 containsFlavor 'no-recommends' && {
     APT_GET_OPTIONS+=" -o APT::Install-Recommends=0  -o APT::Install-Suggests=0" 

--- a/template_debian/vars.sh
+++ b/template_debian/vars.sh
@@ -42,6 +42,11 @@ if [ "0${BUILDER_TURBO_MODE}" -gt 0 ]; then
     eatmydata_maybe=eatmydata
 fi
 
+if [ -n "$REPO_PROXY" ]; then
+    APT_GET_OPTIONS+=" -o Acquire::http::Proxy=${REPO_PROXY}"
+    DEBOOTSTRAP_PREFIX+=" env http_proxy=${REPO_PROXY}"
+fi
+
 containsFlavor 'no-recommends' && {
     APT_GET_OPTIONS+=" -o APT::Install-Recommends=0  -o APT::Install-Suggests=0" 
 } || true

--- a/template_qubuntu/vars.sh
+++ b/template_qubuntu/vars.sh
@@ -22,7 +22,12 @@ DEBIAN_MIRRORS=(
 # ------------------------------------------------------------------------------
 # apt-get configuration options
 # ------------------------------------------------------------------------------
-APT_GET_OPTIONS="-o Dpkg::Options::="--force-confnew" --yes"
+APT_GET_OPTIONS="-o Dpkg::Options::=--force-confnew -o Dpkg::Options::=--force-unsafe-io --yes"
+
+if [ "0${BUILDER_TURBO_MODE}" -gt 0 ]; then
+    APT_GET_OPTIONS+=" -o Dpkg::Options::=--force-unsafe-io"
+    eatmydata_maybe=eatmydata
+fi
 
 containsFlavor 'no-recommends' && {
     APT_GET_OPTIONS+=" -o APT::Install-Recommends=0  -o APT::Install-Suggests=0" 


### PR DESCRIPTION
`dpkg` is quite slow in installing packages, most likely because it calls fsync() at each file. In Qubes IO have noticeable latency, especially when building template (effectively two loop device layers, or even three when building in DispVM).
Those patches disables most of fsync calls, which greatly improve performance (`prepare-chroot-debian` takes 10min compared to over 40 earlier). `debootstrap` itself still still calls fsync, because I haven't found a way to pass `dpkg` options there and Fedora doesn't have `eatmydata` package.

Of course, there is nothing for free - here we pay with data integrity - if the system crashes during chroot/template preparation, most likely the only option would be to remove it and generate again.  @nrgaway, do we care?