### PR TITLE
fix dbus machine id deletion error handling

### DIFF
--- a/template_debian/distribution.sh
+++ b/template_debian/distribution.sh
@@ -88,7 +88,7 @@ function createDbusUuid() {
 function removeDbusUuid() {
     if [ -e "${INSTALLDIR}"/var/lib/dbus/machine-id ]; then
         outputc red "Removing generated machine uuid..."
-        rm -f "${INSTALLDIR}/var/lib/dbus/machine-id"
+        rm "${INSTALLDIR}/var/lib/dbus/machine-id"
     fi
 }
 


### PR DESCRIPTION
It's already protected by:
`if [ -e "${INSTALLDIR}"/var/lib/dbus/machine-id ]; then`
Therefore removing `-f`:
`rm -f "${INSTALLDIR}/var/lib/dbus/machine-id"`
->
`rm "${INSTALLDIR}/var/lib/dbus/machine-id"`
Otherwise it could happen, that the file does not get deleted (imagine `chattr +i` or disk issues) while `rm` would still exit `0`.

(We could consider running it under `timeout` to avoid blocking interactive `rm: remove write-protected regular file ‘testfile’?` questions. This happens if you try to delete a file that was set `chattr +i` as non-root user. But I guess that would be overkill.)