### PR TITLE
removed chrony and ntpdate from template_debian/packages_qubes.list

### DIFF
--- a/template_debian/packages_qubes.list
+++ b/template_debian/packages_qubes.list
@@ -1,7 +1,5 @@
 qubes-core-agent
 qubes-gui-agent
-chrony
-ntpdate
 libxvmc1
 x11-session-utils
 xfonts-100dpi


### PR DESCRIPTION
As per https://github.com/QubesOS/qubes-issues/issues/1102.
`template_debian/packages_qubes.list` contains `qubes-core-agent-linux`, which `Recommends:` `ntpdate`.
So there is no need to explicitly list `ntpdate` within `template_debian/packages_qubes.list`.
This helps building templates flavors `no-recommends` such as Whonix to prevent installation of `chrony` and `ntpdate`.