### PR TITLE
Removed superfluous/problematic package chrony from template_debian/packages_qubes.list.

### DIFF
--- a/template_debian/packages_qubes.list
+++ b/template_debian/packages_qubes.list
@@ -1,6 +1,5 @@
 qubes-core-agent
 qubes-gui-agent
-chrony
 ntpdate
 libxvmc1
 x11-session-utils


### PR DESCRIPTION
As per https://github.com/QubesOS/qubes-issues/issues/1102.