### PR TITLE
do not install non-free package firmware-linux by default

### DIFF
--- a/template_debian/packages_jessie.list
+++ b/template_debian/packages_jessie.list
@@ -13,6 +13,5 @@ libglib2.0-bin
 ltrace
 strace
 haveged
-firmware-linux
 wireless-tools
 wpasupplicant

--- a/template_debian/packages_qubes_standard.list
+++ b/template_debian/packages_qubes_standard.list
@@ -2,8 +2,7 @@ xdg-user-dirs
 gnome-themes-standard
 xsettingsd
 gnome-packagekit
-
 qubes-pdf-converter
 qubes-gpg-split
 qubes-thunderbird
-
+firmware-linux

--- a/template_debian/packages_stretch.missing
+++ b/template_debian/packages_stretch.missing
@@ -1,1 +1,0 @@
-firmware-linux


### PR DESCRIPTION
Install linux-firmware in packages_qubes_standard rather than packages_jessie.

- removed linux-firmware* from template_debian/packages_jessie.list
- added linux-firmware to template_debian/packages_qubes_standard.list
- deleted unused template_debian/packages_stretch.missing

This allows building templates (such as Whonix) without having the non-free
package linux-firmware and linux-firmware-nonfree installed.

Fixes https://github.com/QubesOS/qubes-issues/issues/1177