### PR TITLE
install cryptsetup and lvm2 by default

### DIFF
--- a/template_debian/packages_qubes_standard.list
+++ b/template_debian/packages_qubes_standard.list
@@ -6,3 +6,5 @@ qubes-pdf-converter
 qubes-gpg-split
 qubes-thunderbird
 firmware-linux
+cryptsetup
+lvm2


### PR DESCRIPTION
to ease using encrypted usb

Fixes https://github.com/QubesOS/qubes-issues/issues/1496.

Thanks to @mfc for reporting this!