### PR TITLE
install the apt-transport-https package by default

### DIFF
--- a/template_debian/packages_qubes_standard.list
+++ b/template_debian/packages_qubes_standard.list
@@ -6,3 +6,4 @@ qubes-pdf-converter
 qubes-gpg-split
 qubes-thunderbird
 firmware-linux
+apt-transport-https


### PR DESCRIPTION
Note, this does not automagically download from all apt repositories by default.

Quote [1]:

> This package enables the usage of 'deb https://foo distro main' lines in the /etc/apt/sources.list so that all package managers using the libapt-pkg library can access metadata and packages available in sources accessible over https (Hypertext Transfer Protocol Secure).

> This transport supports server as well as client authentication with certificates.

This is part of https://github.com/QubesOS/qubes-issues/issues/1539.

[1] https://packages.debian.org/jessie/apt-transport-https