### PR TITLE
install apt-transport-tor package by default

### DIFF
--- a/template_debian/packages_qubes_standard.list
+++ b/template_debian/packages_qubes_standard.list
@@ -9,3 +9,4 @@ firmware-linux
 cryptsetup
 lvm2
 apt-transport-https
+apt-transport-tor


### PR DESCRIPTION
Simplifies switching to `.onion` repositories.

https://github.com/QubesOS/qubes-issues/issues/1159