### PR TITLE
install exfat-fuse by default

### DIFF
--- a/template_debian/packages_qubes_standard.list
+++ b/template_debian/packages_qubes_standard.list
@@ -9,3 +9,4 @@ firmware-linux
 cryptsetup
 lvm2
 apt-transport-https
+exfat-fuse


### PR DESCRIPTION
Simplifies using exFAT formatted external drives / partitions.

https://github.com/QubesOS/qubes-issues/issues/1054